### PR TITLE
disable powerline precmd hook

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -118,7 +118,8 @@ function install_powerline_precmd() {
   precmd_functions+=(powerline_precmd)
 }
 
-install_powerline_precmd
+# Disabled because it has no effect when using Powerlevel10k but slows down prompt by a lot.
+# install_powerline_precmd
 
 # Init rbenv
 eval "$(rbenv init -)"


### PR DESCRIPTION
My apologies for a drive-by PR. Feel free to close without comments if this isn't valuable.

---

`powerline_precmd` has no effect when using Powerlevel10k but still slows down prompt by a lot.

This PR should have no visible effects apart from making prompt faster.