### PR TITLE
Fix local EDITOR to not return instantly

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -101,7 +101,7 @@ source $ZSH/oh-my-zsh.sh
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'
 else
-  export EDITOR='code'
+  export EDITOR='code --wait'
 fi
 
 # Go to the root of the current git project, or just go one folder up


### PR DESCRIPTION
For example when you do `git merge other-branch`, simply having `code` as your editor will instantly return, so you won't have the chance to change the commit message.